### PR TITLE
change region and add user in ansible

### DIFF
--- a/01-jenkins-setup/ansible/scripts/get-ssh-pub.py
+++ b/01-jenkins-setup/ansible/scripts/get-ssh-pub.py
@@ -2,6 +2,6 @@ import boto3
 import json
 import sys
 
-client = boto3.client('ssm', region_name='us-east-1')
+client = boto3.client('ssm', region_name='us-west-2')
 response = client.get_parameter(Name=sys.argv[1], WithDecryption=True)
 print(response['Parameter']['Value'])

--- a/01-jenkins-setup/jenkins-agent.pkr.hcl
+++ b/01-jenkins-setup/jenkins-agent.pkr.hcl
@@ -15,8 +15,8 @@ locals {
 source "amazon-ebs" "jenkins" {
   ami_name      = "${local.app_name}"
   instance_type = "t2.micro"
-  region        = "us-east-1"
-  availability_zone = "us-east-1c"
+  region        = "us-west-2"
+  availability_zone = "us-west-2b"
   source_ami    = "${var.ami_id}"
   ssh_username  = "ubuntu"
   iam_instance_profile = "jenkins-instance-profile"
@@ -31,6 +31,7 @@ build {
 
   provisioner "ansible" {
   playbook_file = "ansible/jenkins-agent.yaml"
+  user          = "ubuntu"
   extra_arguments = [ "--extra-vars", "public_key_path=${var.public_key_path}",  "--scp-extra-args", "'-O'", "--ssh-extra-args", "-o IdentitiesOnly=yes -o HostKeyAlgorithms=+ssh-rsa" ]
   } 
   

--- a/01-jenkins-setup/jenkins-controller.pkr.hcl
+++ b/01-jenkins-setup/jenkins-controller.pkr.hcl
@@ -15,8 +15,8 @@ locals {
 source "amazon-ebs" "jenkins" {
   ami_name      = "${local.app_name}"
   instance_type = "t2.micro"
-  region        = "us-east-1"
-  availability_zone = "us-east-1d"
+  region        = "us-west-2"
+  availability_zone = "us-west-2b"
   source_ami    = "${var.ami_id}"
   ssh_username  = "ubuntu"
   tags = {
@@ -30,6 +30,7 @@ build {
 
   provisioner "ansible" {
   playbook_file = "ansible/jenkins-controller.yaml"
+  ssh_username  = "ubuntu"
   extra_arguments = [ "--extra-vars", "ami-id=${var.ami_id} efs_mount_point=${var.efs_mount_point}", "--scp-extra-args", "'-O'", "--ssh-extra-args", "-o IdentitiesOnly=yes -o HostKeyAlgorithms=+ssh-rsa" ]
   } 
   

--- a/01-jenkins-setup/terraform/agent/main.tf
+++ b/01-jenkins-setup/terraform/agent/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "us-east-1"
+  region = "us-west-2"
 }
 
 module "ec2_instance" {
@@ -7,7 +7,7 @@ module "ec2_instance" {
   instance_name      = "jenkins-agent"
   ami_id             = "ami-0fe5ed92a8c77d79f"
   instance_type      = "t2.small"
-  key_name           = "jenkinskey"
+  key_name           = "techiescamp"
   subnet_ids         = ["subnet-046c3f4390fc51b7e", "subnet-02727435b393c516c", "subnet-0ed1c80066f1be7ed"]
   instance_count     = 1
 }

--- a/01-jenkins-setup/terraform/efs/main.tf
+++ b/01-jenkins-setup/terraform/efs/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "us-east-1"
+  region = "us-west-2"
 }
 
 module "efs_module" {

--- a/01-jenkins-setup/terraform/iam/main.tf
+++ b/01-jenkins-setup/terraform/iam/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "us-east-1"
+  region = "us-west-2"
 }
 
 module "jenkins_iam" {

--- a/01-jenkins-setup/terraform/lb-asg/main.tf
+++ b/01-jenkins-setup/terraform/lb-asg/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "us-east-1"
+  region = "us-west-2"
 }
 
 module "lb-asg" {
@@ -7,7 +7,7 @@ module "lb-asg" {
   subnets       = ["subnet-046c3f4390fc51b7e", "subnet-02727435b393c516c", "subnet-0ed1c80066f1be7ed"]
   ami_id        = "ami-0e9419006a1fc1387"
   instance_type = "t2.small"
-  key_name      = "jenkinskey"
+  key_name      = "techiescamp"
   environment   = "dev"
   vpc_id        = "vpc-0872a2ffd55e763ca"
 }

--- a/01-jenkins-setup/terraform/modules/ec2/variable.tf
+++ b/01-jenkins-setup/terraform/modules/ec2/variable.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "us-east-1"
+  region = "us-west-2"
 }
 
 variable "instance_name" {
@@ -19,7 +19,7 @@ variable "instance_type" {
 
 variable "key_name" {
   type = string
-  default = "jenkinskey"
+  default = "techiescamp"
 }
 
 variable "security_group_ids" {


### PR DESCRIPTION
1. Region Mismatch

    Updated the Terraform region from us-east-1 to us-west-2 to match the course instructions.

2. Ansible SSH Error During AMI Creation

    Fixed the Ansible SSH issue by setting user = "ubuntu" in the Terraform files.

    This is required because the default Ubuntu AMI does not allow SSH as root.